### PR TITLE
Resolve/dispute formula

### DIFF
--- a/db/db_interactions/helpers.js
+++ b/db/db_interactions/helpers.js
@@ -27,6 +27,46 @@ const deleteRow = function (tableName, rowId) {
     })
 }
 
+const modifyEntry = function (tableName, colName, newVal, conditionCol, conditionVal) {
+    return new Promise((resolve, reject) => {
+        const modifyEntry = `UPDATE ${tableName} SET ${colName}=${newVal} WHERE ${conditionCol}=${conditionVal}` + ';'
+        console.log(modifyEntry);
+        connection.query(modifyEntry, (err, value) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(value);
+            }
+        })
+    })
+}
+
+const selectVal = function (tableName, colName, conditionCol, conditionVal, returnKey) {
+    return new Promise((resolve, reject) => {
+        const selectEntry = `SELECT ${colName} FROM ${tableName} WHERE ${conditionCol}=${conditionVal}` + ';'
+        connection.query(selectEntry, (err, value) => {
+            if (err) {
+                reject(err);
+            } else {
+                console.log('resolveVal helper', value[0].status)
+                resolve(value[0][returnKey]);
+            }
+        })
+    })
+}
+
+const promisedQuery = function (query) {
+    return new Promise((resolve, reject) => {
+        connection.query(query, (err, value) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(value);
+            }
+        })
+    })
+}
+
 const getCanAmplify = function (postId, userId) {
     return new Promise((resolve, reject) => {
         if (!userId) {
@@ -97,4 +137,4 @@ const getContacts = function (categoryId) {
         })
     })
 }
-module.exports = { getRow, deleteRow, getCanAmplify, getFavorited, getCategoryName, getContacts }
+module.exports = { getRow, deleteRow, modifyEntry, selectVal, promisedQuery, getCanAmplify, getFavorited, getCategoryName, getContacts }

--- a/db/db_interactions/postStatus.js
+++ b/db/db_interactions/postStatus.js
@@ -1,4 +1,5 @@
 const connection = require('../db');
+const helpers = require('./helpers');
 
 const validateUserId = function (userId) {
     return new Promise((resolve, reject) => {
@@ -158,55 +159,176 @@ const modifyAmplifies = function (userId, postId) {
     })
 }
 
+
+
 const markResolved = function (userId, postId) {
     return new Promise((resolve, reject) => {
-        const testQuery = "SELECT status FROM posts WHERE id = " + postId + ";";
-        connection.query(testQuery, (err, value) => {
-            if (err) {
-                reject(err);
-            } else {
-                //if they already favorited, delete the row
-                if (value[0]) {
-                    const resolvedQuery = "UPDATE posts SET status='resolved' WHERE id=" + postId + ";";
-                    connection.query(resolvedQuery, (err, value) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(`post ${postId} marked resolved`);
-                        }
-                    })
+        //test userId & postId are valid
+        validateUserId(userId)
+            .then((value) => {
+                if (value === 'invalid userId') {
+                    resolve(value);
                 } else {
-                    resolve(`post ${postId} does not exist`)
+                    return validatePostId(postId)
                 }
-            }
-        })
+            })
+            .then((value) => {
+                if (value === 'invalid postId') {
+                    resolve(value);
+                } else {
+                    //get post details
+                    helpers.getRow('posts', postId)
+                        .then((value) => {
+                            const status = value[0].status;
+                            const resolved = value[0].resolved;
+                            const creatorId = value[0].creatorId;
+
+                            //test that user has not already marked resolved
+                            const query = `SELECT id FROM resolves WHERE userId=${userId} AND postId=${postId};`;
+                            helpers.promisedQuery(query)
+                                .then((value) => {
+                                    //user has already marked a post resolved, do nothing but return status
+                                    if (value.length > 0) {
+                                        resolve(status)
+                                        //user has not already marked a post resolved, rest of logic...
+                                    } else {
+                                        //if not already resolved
+                                        if (status !== 'resolved') {
+                                            //if user is the post creator OR adding one more resolved would make more than 2 resolveds
+                                            if (creatorId == userId || resolved >= 2) {
+                                                //mark resolved
+                                                helpers.modifyEntry('posts', 'status', "'resolved'", 'id', postId)
+                                                    //reset resolved count
+                                                    .then((value) => {
+                                                        return helpers.modifyEntry('posts', 'resolved', 0, 'id', postId)
+                                                    })
+                                                    //reset resolve join table for specefic postId
+                                                    .then((value) => {
+                                                        const resetResolveTbl = `DELETE FROM resolves WHERE postId= ${postId};`;
+                                                        return helpers.promisedQuery(resetResolveTbl);
+                                                    })
+                                                    .then((value) => {
+                                                        //get status
+                                                        return helpers.selectVal('posts', 'status', 'id', postId, 'status')
+                                                    })
+                                                    .then((value) => {
+                                                        //resolve status
+                                                        resolve(value)
+                                                    })
+                                            } else {
+                                                //status wont change, but resolved count needs to be updated & joint table updated
+                                                helpers.modifyEntry('posts', 'resolved', resolved + 1, 'id', postId)
+                                                    .then((value) => {
+                                                        const insertResolveTbl = `INSERT INTO resolves (userId, postId) VALUES (${userId}, ${postId});`;
+                                                        return helpers.promisedQuery(insertResolveTbl);
+                                                    })
+                                                    .then((value) => {
+                                                        //resolve status
+                                                        return helpers.selectVal('posts', 'status', 'id', postId, 'status')
+                                                    })
+                                                    .then((value) => {
+                                                        //resolve status
+                                                        resolve(value)
+                                                    })
+                                            }
+                                        } else {
+                                            resolve(status);
+                                        }
+                                    }
+                                })
+                        })
+                        .catch((err) => {
+                            if (err) {
+                                reject(err);
+                            }
+                        })
+                }
+            })
     })
 }
 
 const dispute = function (userId, postId) {
     return new Promise((resolve, reject) => {
-        //find post status
-        const testQuery = "SELECT status FROM posts WHERE id = " + postId + ";";
-        connection.query(testQuery, (err, value) => {
-            if (err) {
-                reject(err);
-            } else {
-                //if postId valid, make disputed
-                if (value[0]) {
-                    const disputedQuery = "UPDATE posts SET status='disputed' WHERE id=" + postId + ";";
-                    connection.query(disputedQuery, (err, value) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(`postId ${postId} marked disputed`);
-                        }
-                    })
+        //test userId & postId are valid
+        validateUserId(userId)
+            .then((value) => {
+                if (value === 'invalid userId') {
+                    resolve(value);
+                } else {
+                    return validatePostId(postId)
                 }
-                else {
-                    resolve(`post ${postId} does not exist`)
+            })
+            .then((value) => {
+                if (value === 'invalid postId') {
+                    resolve(value);
+                } else {
+                    //get post details
+                    helpers.getRow('posts', postId)
+                        .then((value) => {
+                            const status = value[0].status;
+                            const disputed = value[0].disputed;
+
+                            //test that user has not already marked disputed
+                            const query = `SELECT id FROM disputes WHERE userId=${userId} AND postId=${postId};`;
+                            helpers.promisedQuery(query)
+                                .then((value) => {
+                                    //user has already marked a post disputed, do nothing but return status
+                                    if (value.length > 0) {
+                                        resolve(status)
+                                        //user has not already marked a post disputed, rest of logic...
+                                    } else {
+                                        //if not already disputed
+                                        if (status === 'resolved') {
+                                            //if adding one more dispute would make more than 2 disputes
+                                            if (disputed >= 2) {
+                                                //mark disputed
+                                                helpers.modifyEntry('posts', 'status', "'disputed'", 'id', postId)
+                                                    //reset disputed count
+                                                    .then((value) => {
+                                                        return helpers.modifyEntry('posts', 'disputed', 0, 'id', postId)
+                                                    })
+                                                    //reset disputes join table for specefic postId
+                                                    .then((value) => {
+                                                        const resetDisputesTbl = `DELETE FROM disputes WHERE postId= ${postId};`;
+                                                        return helpers.promisedQuery(resetDisputesTbl);
+                                                    })
+                                                    .then((value) => {
+                                                        //get status
+                                                        return helpers.selectVal('posts', 'status', 'id', postId, 'status')
+                                                    })
+                                                    .then((value) => {
+                                                        //resolve status
+                                                        resolve(value)
+                                                    })
+                                            } else {
+                                                //status wont change, but dispute count needs to be updated & join table updated
+                                                helpers.modifyEntry('posts', 'disputed', disputed + 1, 'id', postId)
+                                                    .then((value) => {
+                                                        const insertDisputesTbl = `INSERT INTO disputes (userId, postId) VALUES (${userId}, ${postId});`;
+                                                        return helpers.promisedQuery(insertDisputesTbl);
+                                                    })
+                                                    .then((value) => {
+                                                        //resolve status
+                                                        return helpers.selectVal('posts', 'status', 'id', postId, 'status')
+                                                    })
+                                                    .then((value) => {
+                                                        //resolve status
+                                                        resolve(value)
+                                                    })
+                                            }
+                                        } else {
+                                            resolve(status);
+                                        }
+                                    }
+                                })
+                        })
+                        .catch((err) => {
+                            if (err) {
+                                reject(err);
+                            }
+                        })
                 }
-            }
-        })
+            })
     })
 }
 


### PR DESCRIPTION
routes to resolve and dispute end points now fully functional:
-a user can mark an open or disputed post resolved
-each user can only mark a post resolved once (unless status changes to resolved and back again)
-if a post creator marks a post resolved, the status is immediately changed to resolved
-if anyone else marks a post resolved, it increments the resolved count on posts table
-after 3 resolved counts, the post status is changed to resolved, and count is reset

-a user can mark a resolved post disputed
-after 3 users mark a resolved post disputed, the status is changed to disputed and disputed count reset
