### PR TITLE
Tweak/resolve dispute flow

### DIFF
--- a/db/db_interactions/helpers.js
+++ b/db/db_interactions/helpers.js
@@ -29,8 +29,7 @@ const deleteRow = function (tableName, rowId) {
 
 const modifyEntry = function (tableName, colName, newVal, conditionCol, conditionVal) {
     return new Promise((resolve, reject) => {
-        const modifyEntry = `UPDATE ${tableName} SET ${colName}=${newVal} WHERE ${conditionCol}=${conditionVal}` + ';'
-        console.log(modifyEntry);
+        const modifyEntry = `UPDATE ${tableName} SET ${colName}=${newVal} WHERE ${conditionCol}=${conditionVal}` + ';';
         connection.query(modifyEntry, (err, value) => {
             if (err) {
                 reject(err);
@@ -47,9 +46,10 @@ const selectVal = function (tableName, colName, conditionCol, conditionVal, retu
         connection.query(selectEntry, (err, value) => {
             if (err) {
                 reject(err);
-            } else {
-                console.log('resolveVal helper', value[0].status)
+            } else if (returnKey) {
                 resolve(value[0][returnKey]);
+            } else {
+                resolve(value[0])
             }
         })
     })

--- a/db/db_interactions/postStatus.js
+++ b/db/db_interactions/postStatus.js
@@ -189,7 +189,7 @@ const markResolved = function (userId, postId) {
                                 .then((value) => {
                                     //user has already marked a post resolved
                                     if (value.length > 0) {
-                                        const userResolved = false;
+                                        const userMarked = false;
                                         //DELETE THE RESOLVE TO ALLOW A USER TO UNDO THEIR RESOLVE
                                         const queryString = `DELETE FROM resolves WHERE userId = ${userId} AND postId = ${postId}`;
                                         helpers.promisedQuery(queryString)
@@ -202,7 +202,7 @@ const markResolved = function (userId, postId) {
                                                 return helpers.selectVal('posts', '*', 'id', postId)
                                             })
                                             .then((value) => {
-                                                resolve({ status: value.status, resolved: value.resolved, userResolved: userResolved })
+                                                resolve({ status: value.status, count: value.resolved, userMarked: userMarked })
                                             })
 
                                         //user has not already marked a post resolved...
@@ -211,7 +211,7 @@ const markResolved = function (userId, postId) {
                                         if (status !== 'resolved') {
                                             //if user is the post creator OR adding one more resolved would make more than 2 resolveds
                                             if (creatorId == userId || resolved >= 2) {
-                                                const userResolved = false;
+                                                const userMarked = false;
                                                 //mark resolved
                                                 helpers.modifyEntry('posts', 'status', "'resolved'", 'id', postId)
                                                     //reset resolved count
@@ -229,10 +229,10 @@ const markResolved = function (userId, postId) {
                                                     })
                                                     .then((value) => {
                                                         //resolve status
-                                                        resolve({ status: value.status, resolved: value.resolved, userResolved: userResolved })
+                                                        resolve({ status: value.status, count: value.resolved, userMarked: userMarked })
                                                     })
                                             } else {
-                                                const userResolved = true;
+                                                const userMarked = true;
                                                 //status wont change, but resolved count needs to be updated & joint table updated
                                                 helpers.modifyEntry('posts', 'resolved', resolved + 1, 'id', postId)
                                                     .then((value) => {
@@ -245,11 +245,11 @@ const markResolved = function (userId, postId) {
                                                     })
                                                     .then((value) => {
                                                         //resolve status
-                                                        resolve({ status: value.status, resolved: value.resolved, userResolved: userResolved })
+                                                        resolve({ status: value.status, count: value.resolved, userMarked: userMarked })
                                                     })
                                             }
                                         } else {
-                                            resolve({ status, resolved, userResolved: false });
+                                            resolve({ status: status, count: resolved, userMarked: false });
                                         }
                                     }
                                 })
@@ -284,7 +284,6 @@ const dispute = function (userId, postId) {
                         .then((value) => {
                             const status = value[0].status;
                             const disputed = value[0].disputed;
-                            const creatorId = value[0].creatorId;
 
                             //test that user has not already marked disputed
                             const query = `SELECT id FROM disputes WHERE userId=${userId} AND postId=${postId};`;
@@ -292,7 +291,7 @@ const dispute = function (userId, postId) {
                                 .then((value) => {
                                     //user has already marked a post disputed
                                     if (value.length > 0) {
-                                        const userDisputed = false;
+                                        const userMarked = false;
                                         //DELETE THE DISPUTE TO ALLOW A USER TO UNDO THEIR DISPUTE
                                         const queryString = `DELETE FROM disputes WHERE userId = ${userId} AND postId = ${postId}`;
                                         helpers.promisedQuery(queryString)
@@ -305,7 +304,7 @@ const dispute = function (userId, postId) {
                                                 return helpers.selectVal('posts', '*', 'id', postId)
                                             })
                                             .then((value) => {
-                                                resolve({ status: value.status, disputed: value.disputed, userDisputed: userDisputed })
+                                                resolve({ status: value.status, count: value.disputed, userMarked: userMarked })
                                             })
 
                                         //user has not already marked a post resolved...
@@ -314,7 +313,7 @@ const dispute = function (userId, postId) {
                                         if (status === 'resolved') {
                                             //if adding one more dispute would make more than 2 disputeds
                                             if (disputed >= 2) {
-                                                const userDisputed = false;
+                                                const userMarked = false;
                                                 //mark disputed
                                                 helpers.modifyEntry('posts', 'status', "'disputed'", 'id', postId)
                                                     //reset dispute count
@@ -332,10 +331,10 @@ const dispute = function (userId, postId) {
                                                     })
                                                     .then((value) => {
                                                         //resolve status
-                                                        resolve({ status: value.status, disputed: value.disputed, userDisputed: userDisputed })
+                                                        resolve({ status: value.status, count: value.disputed, userMarked: userMarked })
                                                     })
                                             } else {
-                                                const userDisputed = true;
+                                                const userMarked = true;
                                                 //status wont change, but resolved count needs to be updated & joint table updated
                                                 helpers.modifyEntry('posts', 'disputed', disputed + 1, 'id', postId)
                                                     .then((value) => {
@@ -348,11 +347,11 @@ const dispute = function (userId, postId) {
                                                     })
                                                     .then((value) => {
                                                         //resolve status
-                                                        resolve({ status: value.status, disputed: value.disputed, userDisputed: userDisputed })
+                                                        resolve({ status: value.status, count: value.disputed, userMarked: userMarked })
                                                     })
                                             }
                                         } else {
-                                            resolve({ status: status, disputed: disputed, userResolved: false });
+                                            resolve({ status: status, count: disputed, userMarked: false });
                                         }
                                     }
                                 })

--- a/db/db_interactions/postStatus.js
+++ b/db/db_interactions/postStatus.js
@@ -187,18 +187,31 @@ const markResolved = function (userId, postId) {
                             const query = `SELECT id FROM resolves WHERE userId=${userId} AND postId=${postId};`;
                             helpers.promisedQuery(query)
                                 .then((value) => {
-                                    //user has already marked a post resolved, do nothing but return status
+                                    //user has already marked a post resolved
                                     if (value.length > 0) {
-                                        resolve(status)
+                                        const userResolved = false;
+                                        //DELETE THE RESOLVE TO ALLOW A USER TO UNDO THEIR RESOLVE
                                         const queryString = `DELETE FROM resolves WHERE userId = ${userId} AND postId = ${postId}`;
-                                        //MAKE A QUERY TO DELETE THE RESOLVE TO ALLOW A USER TO UNDO THEIR RESOLVE
+                                        helpers.promisedQuery(queryString)
+                                            .then((value) => {
+                                                //REDUCE POSTS RESOLVED COUNT
+                                                return helpers.modifyEntry('posts', 'resolved', resolved - 1, 'id', postId)
+                                            })
+                                            .then((value) => {
+                                                //get status
+                                                return helpers.selectVal('posts', '*', 'id', postId)
+                                            })
+                                            .then((value) => {
+                                                resolve({ status: value.status, resolved: value.resolved, userResolved: userResolved })
+                                            })
 
-                                        //user has not already marked a post resolved, rest of logic...
+                                        //user has not already marked a post resolved...
                                     } else {
                                         //if not already resolved
                                         if (status !== 'resolved') {
                                             //if user is the post creator OR adding one more resolved would make more than 2 resolveds
                                             if (creatorId == userId || resolved >= 2) {
+                                                const userResolved = false;
                                                 //mark resolved
                                                 helpers.modifyEntry('posts', 'status', "'resolved'", 'id', postId)
                                                     //reset resolved count
@@ -212,13 +225,14 @@ const markResolved = function (userId, postId) {
                                                     })
                                                     .then((value) => {
                                                         //get status
-                                                        return helpers.selectVal('posts', 'status', 'id', postId, 'status')
+                                                        return helpers.selectVal('posts', '*', 'id', postId)
                                                     })
                                                     .then((value) => {
                                                         //resolve status
-                                                        resolve(value)
+                                                        resolve({ status: value.status, resolved: value.resolved, userResolved: userResolved })
                                                     })
                                             } else {
+                                                const userResolved = true;
                                                 //status wont change, but resolved count needs to be updated & joint table updated
                                                 helpers.modifyEntry('posts', 'resolved', resolved + 1, 'id', postId)
                                                     .then((value) => {
@@ -227,15 +241,15 @@ const markResolved = function (userId, postId) {
                                                     })
                                                     .then((value) => {
                                                         //resolve status
-                                                        return helpers.selectVal('posts', 'status', 'id', postId, 'status')
+                                                        return helpers.selectVal('posts', '*', 'id', postId)
                                                     })
                                                     .then((value) => {
                                                         //resolve status
-                                                        resolve(value)
+                                                        resolve({ status: value.status, resolved: value.resolved, userResolved: userResolved })
                                                     })
                                             }
                                         } else {
-                                            resolve(status);
+                                            resolve({ status, resolved, userResolved: false });
                                         }
                                     }
                                 })
@@ -277,7 +291,7 @@ const dispute = function (userId, postId) {
                                 .then((value) => {
                                     //user has already marked a post disputed, do nothing but return status
                                     if (value.length > 0) {
-                                        resolve(status)
+                                        resolve({ status, disputed })
                                         //user has not already marked a post disputed, rest of logic...
                                     } else {
                                         //if not already disputed
@@ -301,7 +315,7 @@ const dispute = function (userId, postId) {
                                                     })
                                                     .then((value) => {
                                                         //resolve status
-                                                        resolve(value)
+                                                        resolve({ value, disputed })
                                                     })
                                             } else {
                                                 //status wont change, but dispute count needs to be updated & join table updated
@@ -316,11 +330,11 @@ const dispute = function (userId, postId) {
                                                     })
                                                     .then((value) => {
                                                         //resolve status
-                                                        resolve(value)
+                                                        resolve({ value, disputed })
                                                     })
                                             }
                                         } else {
-                                            resolve(status);
+                                            resolve({ status, disputed });
                                         }
                                     }
                                 })


### PR DESCRIPTION
-if a user has marked a post resolved/disputed, sending another request to the same route removes their resolve/dispute vote (unless the status changed)
-the response from these routes now returns STATUS (open, resolved, or disputed), COUNT (number of votes received to change the status to next stage), and USERMARKED (wether the user has already marked this post resolved/disputed).